### PR TITLE
Update dspace-installer.sh

### DIFF
--- a/dspace-installer.sh
+++ b/dspace-installer.sh
@@ -213,6 +213,7 @@ percent=1
 
 # Instala o SGBD no sistema [PostgreSQL]
 {
+	apt-get update
 	apt-get install postgresql -y
 } &>/dev/null &
 pid=$!


### PR DESCRIPTION
Inclusão do comando `apt-get update` para evitar erros durante a instalação do Banco de Dados.